### PR TITLE
Add `translate` inside Exception Catch

### DIFF
--- a/src/Actions/TranslatableAction.php
+++ b/src/Actions/TranslatableAction.php
@@ -47,10 +47,9 @@ class TranslatableAction
                             } else {
                                 $text = $component->getState();
                             }
-
-                            $googleTranslate = $googleTranslate->translate($source, $data['target'], $text);
-
+                            
                             try {
+                                $googleTranslate = $googleTranslate->translate($source, $data['target'], $text);
                                 $component->state($googleTranslate);
 
                                 $livewire->dispatch('refresh-tiptap-editors', [
@@ -66,7 +65,7 @@ class TranslatableAction
                             } catch (\Exception $exception) {
                                 Notification::make()
                                     ->title(__('filament-translate-action::filament-translate-action.error_title'))
-                                    ->body(__('filament-translate-action::filament-translate-action.error_message'))
+                                    ->body(__('filament-translate-action::filament-translate-action.error_message'). '<br/>' . $exception->getMessage())
                                     ->danger()
                                     ->send();
 


### PR DESCRIPTION
Instead of showing an Exception error return a message error via Filament notification method.
